### PR TITLE
Make conda noarch

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -10,11 +10,13 @@ source:
     git_url: ../
 
 build:
-    script: python setup.py install
+    script: "{{ PYTHON }} -m pip install . --no-deps"
+    noarch: python
 
 requirements:
     build:
         - python
+        - pip
         - pbr
     run:
         - python


### PR DESCRIPTION
Add noarch to allow the conda package to be used on other python versions