### PR TITLE
Add back pypi deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,12 +24,13 @@ script:
 after_success:
     - codecov
     - codeclimate-test-reporter
-# deploy:
-#   provider: pypi
-#   user: aidanheerdegen 
-#   password:
-#     secure: "Q+iWh5IvEBKyeEy5xNghszSMHngpmY6sPJav18d0SGhTiHJCBvWXmbxM+41ILEPr+Gcqb6FmOFJ10reqvz2DbSEwArjjCO+fg7dOsyUYPlF0DZI2FbxUCaoi5VVP4DXNSiIGqeAe2+j4AnIyk2TJH/oe1uJDmkrDsr+ZchbA0OmNMZ04Ma1vt6jGvIxxfgDGKXI3PGvD3lYH7wsEaeTj5R5JHTXO7CcPN0aLy0Lw0OXKLcv4do4lkFDCqSzuJ3aM1xp1Iz3oNoXB6lLC2A5JnlblGqk61zeOY8Z3wpurOMvktL9pvUIURsbhGHoiA9X6e9QVw87tQBb+gN2gWTvVRQpKsV4GvtYpm4vtOhQydv/uJSZ+ZdS1epCDin9tXKMbjWW+VA+CpFyIaHqPYFt8lKoiMCVuFgfHidbh7tbXLCnYcVdBt4ZBKGGNGBwOz0c3aU0SLTgS6ipXQvoG00DXXI/D0jkKfWuVkXSdFrygy2+atuAV9V/hjV6KwS+1JziLvJaC1r9j8S9tBVBPXUyFqglFXUQ+TW/awOyNAxqd7QwpGGsjdcnmZnWyilWPa30Cw/qL/Ao3c2LdoXVFZiNsX1R+m3kMuIFj2vFUZ9IyclHQnBFzHu4q5UcNrQczPTqanL/f/CPnYta0TXBORIjKN+gNsP5Nz3OmqcPOP9iSl3k=" 
-#   on:
-#     tags: true
-#     # repo: aidanheerdegen/yamanifest
-#   distributions: "sdist"
+
+deploy:
+   provider: pypi
+   user: aidanheerdegen 
+   password:
+     secure: "Q+iWh5IvEBKyeEy5xNghszSMHngpmY6sPJav18d0SGhTiHJCBvWXmbxM+41ILEPr+Gcqb6FmOFJ10reqvz2DbSEwArjjCO+fg7dOsyUYPlF0DZI2FbxUCaoi5VVP4DXNSiIGqeAe2+j4AnIyk2TJH/oe1uJDmkrDsr+ZchbA0OmNMZ04Ma1vt6jGvIxxfgDGKXI3PGvD3lYH7wsEaeTj5R5JHTXO7CcPN0aLy0Lw0OXKLcv4do4lkFDCqSzuJ3aM1xp1Iz3oNoXB6lLC2A5JnlblGqk61zeOY8Z3wpurOMvktL9pvUIURsbhGHoiA9X6e9QVw87tQBb+gN2gWTvVRQpKsV4GvtYpm4vtOhQydv/uJSZ+ZdS1epCDin9tXKMbjWW+VA+CpFyIaHqPYFt8lKoiMCVuFgfHidbh7tbXLCnYcVdBt4ZBKGGNGBwOz0c3aU0SLTgS6ipXQvoG00DXXI/D0jkKfWuVkXSdFrygy2+atuAV9V/hjV6KwS+1JziLvJaC1r9j8S9tBVBPXUyFqglFXUQ+TW/awOyNAxqd7QwpGGsjdcnmZnWyilWPa30Cw/qL/Ao3c2LdoXVFZiNsX1R+m3kMuIFj2vFUZ9IyclHQnBFzHu4q5UcNrQczPTqanL/f/CPnYta0TXBORIjKN+gNsP5Nz3OmqcPOP9iSl3k=" 
+   on:
+     tags: true
+     repo: aidanheerdegen/yamanifest
+   distributions: "sdist"

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,3 +1,4 @@
 Aidan Heerdegen <aidan.heerdegen@anu.edu.au>
 Aidan Heerdegen <aidan.heerdegen@gmail.com>
+Scott Wales <scott.wales@unimelb.edu.au>
 Scott Wales <scottwales@outlook.com.au>

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,24 @@
 CHANGES
 =======
 
+0.3.8
+-----
+
+* Removed py27 from publish requirements
+
+0.3.7
+-----
+
+* Bumped python version in conda
+
+0.3.6
+-----
+
+* Changed to safe\_load with yaml
+* CircleCI not building due to PYTHON var missing. Use bare python cmd
+* Specify loader to avoid deprecation warning
+* Make conda noarch
+
 0.3.5
 -----
 


### PR DESCRIPTION
Adding back pypi deployment that was removed in https://github.com/aidanheerdegen/yamanifest/commit/c416586eeaa27ed3b8b798aa56664787710b2288

Not sure why it was removed, and this fixes #9 