### PR TITLE
Feature: optionally hash file path and mod time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+*.ipynb_checkpoints
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/test/test_manifest.py
+++ b/test/test_manifest.py
@@ -63,7 +63,7 @@ def setup_module(module):
     shutil.copytree(os.path.join('test','testfiles'),os.path.join('test','testfiles_copy'))
     make_random_binary_file(os.path.join('test','testfiles_copy','25mb.bin'),25*1024*1024)
     make_random_binary_file(os.path.join('test','testfiles_copy','100mb.bin'),100*1024*1024)
-
+ 
 def teardown_module(module):
     if verbose: print ("teardown_module   module:%s" % module.__name__)
     shutil.rmtree(os.path.join('test','testfiles_copy'),ignore_errors=True)
@@ -477,26 +477,6 @@ def test_specify_fullpath_as_array():
     # Now check the fullpath is the same as the filepath
     for filepath in mf1:
         assert(mf1.fullpath(filepath) == filepath)
-        
-def test_include_mtime():
-    
-    with cd(os.path.join('test','testfiles_copy')):
 
-        mf1 = mf.Manifest(None)
-        mf2 = mf.Manifest(None)
-
-        for filepath in glob.glob('*.bin'):
-            mf1.add(filepath, hashfn='binhash', include_mtime=True)
-            mf2.add(filepath, hashfn='binhash', include_mtime=False)
-            
-        mf3 = mf.Manifest(None)
-        mf4 = mf.Manifest(None)
         
-        for filepath in glob.glob('*.bin'):
-            touch(filepath)
-            mf3.add(filepath, hashfn='binhash', include_mtime=True)
-            mf4.add(filepath, hashfn='binhash', include_mtime=False)
-            
-        assert(not mf1.equals(mf2))
-        assert(not mf1.equals(mf3))
-        assert(mf2.equals(mf4))
+

--- a/test/test_manifest.py
+++ b/test/test_manifest.py
@@ -63,7 +63,7 @@ def setup_module(module):
     shutil.copytree(os.path.join('test','testfiles'),os.path.join('test','testfiles_copy'))
     make_random_binary_file(os.path.join('test','testfiles_copy','25mb.bin'),25*1024*1024)
     make_random_binary_file(os.path.join('test','testfiles_copy','100mb.bin'),100*1024*1024)
- 
+
 def teardown_module(module):
     if verbose: print ("teardown_module   module:%s" % module.__name__)
     shutil.rmtree(os.path.join('test','testfiles_copy'),ignore_errors=True)
@@ -173,7 +173,7 @@ def test_manifest_hash_with_binhash():
         mf4 = mf.Manifest('mf4.yaml')
 
         for filepath in glob.glob('*.bin'):
-            mf4.add(filepath,hashfn='binhash')
+            mf4.add(filepath,hashfn=['binhash', 'binhash-nomtime'])
 
         mf4.dump()
         assert(mf4.check())
@@ -182,7 +182,7 @@ def test_manifest_hash_with_binhash():
 
         for filepath in glob.glob('*.bin'):
             touch(filepath)
-            mf5.add(filepath,hashfn='binhash')
+            mf5.add(filepath,hashfn=['binhash', 'binhash-nomtime'])
 
         hashvals = {}
         assert(not mf4.check())
@@ -478,5 +478,25 @@ def test_specify_fullpath_as_array():
     for filepath in mf1:
         assert(mf1.fullpath(filepath) == filepath)
 
-        
+def test_binhash_nomtime():
 
+    with cd(os.path.join('test','testfiles_copy')):
+
+        mf1 = mf.Manifest(None)
+        mf2 = mf.Manifest(None)
+
+        for filepath in glob.glob('*.bin'):
+            mf1.add(filepath, hashfn='binhash')
+            mf2.add(filepath, hashfn='binhash-nomtime')
+
+        mf3 = mf.Manifest(None)
+        mf4 = mf.Manifest(None)
+
+        for filepath in glob.glob('*.bin'):
+            touch(filepath)
+            mf3.add(filepath, hashfn='binhash')
+            mf4.add(filepath, hashfn='binhash-nomtime')
+
+        assert(not mf1.equals(mf2))
+        assert(not mf1.equals(mf3))
+        assert(mf2.equals(mf4))

--- a/test/test_manifest.py
+++ b/test/test_manifest.py
@@ -63,7 +63,7 @@ def setup_module(module):
     shutil.copytree(os.path.join('test','testfiles'),os.path.join('test','testfiles_copy'))
     make_random_binary_file(os.path.join('test','testfiles_copy','25mb.bin'),25*1024*1024)
     make_random_binary_file(os.path.join('test','testfiles_copy','100mb.bin'),100*1024*1024)
- 
+
 def teardown_module(module):
     if verbose: print ("teardown_module   module:%s" % module.__name__)
     shutil.rmtree(os.path.join('test','testfiles_copy'),ignore_errors=True)
@@ -477,6 +477,26 @@ def test_specify_fullpath_as_array():
     # Now check the fullpath is the same as the filepath
     for filepath in mf1:
         assert(mf1.fullpath(filepath) == filepath)
-
         
+def test_hash_path_info_flag():
+    
+    with cd(os.path.join('test','testfiles_copy')):
 
+        mf1 = mf.Manifest(None)
+        mf2 = mf.Manifest(None)
+
+        for filepath in glob.glob('*.bin'):
+            mf1.add(filepath, hashfn='binhash', hash_path_info=True)
+            mf2.add(filepath, hashfn='binhash', hash_path_info=False)
+            
+        mf3 = mf.Manifest(None)
+        mf4 = mf.Manifest(None)
+        
+        for filepath in glob.glob('*.bin'):
+            touch(filepath)
+            mf3.add(filepath, hashfn='binhash', hash_path_info=True)
+            mf4.add(filepath, hashfn='binhash', hash_path_info=False)
+            
+        assert(not mf1.equals(mf2))
+        assert(not mf1.equals(mf3))
+        assert(mf2.equals(mf4))

--- a/test/test_manifest.py
+++ b/test/test_manifest.py
@@ -478,7 +478,7 @@ def test_specify_fullpath_as_array():
     for filepath in mf1:
         assert(mf1.fullpath(filepath) == filepath)
         
-def test_hash_path_info_flag():
+def test_include_mtime():
     
     with cd(os.path.join('test','testfiles_copy')):
 
@@ -486,16 +486,16 @@ def test_hash_path_info_flag():
         mf2 = mf.Manifest(None)
 
         for filepath in glob.glob('*.bin'):
-            mf1.add(filepath, hashfn='binhash', hash_path_info=True)
-            mf2.add(filepath, hashfn='binhash', hash_path_info=False)
+            mf1.add(filepath, hashfn='binhash', include_mtime=True)
+            mf2.add(filepath, hashfn='binhash', include_mtime=False)
             
         mf3 = mf.Manifest(None)
         mf4 = mf.Manifest(None)
         
         for filepath in glob.glob('*.bin'):
             touch(filepath)
-            mf3.add(filepath, hashfn='binhash', hash_path_info=True)
-            mf4.add(filepath, hashfn='binhash', hash_path_info=False)
+            mf3.add(filepath, hashfn='binhash', include_mtime=True)
+            mf4.add(filepath, hashfn='binhash', include_mtime=False)
             
         assert(not mf1.equals(mf2))
         assert(not mf1.equals(mf3))

--- a/yamanifest/hashing.py
+++ b/yamanifest/hashing.py
@@ -33,7 +33,7 @@ one_hundred_megabytes = 104857600
 # calculation
 supported_hashes = ['nchash', 'md5', 'sha1', 'sha224', 'sha256', 'sha384', 'sha512']
 
-def hash(path, hashfn, size=one_hundred_megabytes):
+def hash(path, hashfn, size=one_hundred_megabytes, hash_file_info=True):
     """ A simple wrapper that inspects the hashing function and intercepts
     calls to nchash and binhash so they are processed in a special way.
 
@@ -54,8 +54,9 @@ def hash(path, hashfn, size=one_hundred_megabytes):
             m = hashlib.new('md5')
             with io.open(path, mode="rb") as fd:
                 # Size limited hashing, so prepend the filename, size and modification time 
-                hashstring = os.path.basename(path) + str(os.path.getsize(path)) + str(os.path.getmtime(path))
-                m.update(hashstring.encode())
+                if hash_file_info:
+                    hashstring = os.path.basename(path) + str(os.path.getsize(path)) + str(os.path.getmtime(path))
+                    m.update(hashstring.encode())
                 tot = 0
                 for chunk in iter(lambda: fd.read(length), b''):
                     tot += len(chunk)

--- a/yamanifest/hashing.py
+++ b/yamanifest/hashing.py
@@ -33,7 +33,7 @@ one_hundred_megabytes = 104857600
 # calculation
 supported_hashes = ['nchash', 'md5', 'sha1', 'sha224', 'sha256', 'sha384', 'sha512']
 
-def hash(path, hashfn, size=one_hundred_megabytes, include_filename=True, include_mtime=True):
+def hash(path, hashfn, size=one_hundred_megabytes):
     """ A simple wrapper that inspects the hashing function and intercepts
     calls to nchash and binhash so they are processed in a special way.
 
@@ -53,13 +53,8 @@ def hash(path, hashfn, size=one_hundred_megabytes, include_filename=True, includ
         elif hashfn == 'binhash':
             m = hashlib.new('md5')
             with io.open(path, mode="rb") as fd:
-                # Size limited hashing, so prepend the size and optionally the filename
-                # and modification time
-                hashstring = str(os.path.getsize(path))
-                if include_filename:
-                    hashstring += os.path.basename(path)
-                if include_mtime:
-                    hashstring += str(os.path.getmtime(path))
+                # Size limited hashing, so prepend the filename, size and modification time 
+                hashstring = os.path.basename(path) + str(os.path.getsize(path)) + str(os.path.getmtime(path))
                 m.update(hashstring.encode())
                 tot = 0
                 for chunk in iter(lambda: fd.read(length), b''):

--- a/yamanifest/hashing.py
+++ b/yamanifest/hashing.py
@@ -31,7 +31,9 @@ one_hundred_megabytes = 104857600
 
 # List of supported hashes and the ordering used to determine relative expense of
 # calculation
-supported_hashes = ['nchash', 'binhash', 'md5', 'sha1', 'sha224', 'sha256', 'sha384', 'sha512']
+supported_hashes = [
+    'nchash', 'binhash', 'binhash-nomtime', 'md5', 'sha1', 'sha224', 'sha256', 'sha384', 'sha512'
+]
 
 def _nchash(path):
     hashval = ''

--- a/yamanifest/hashing.py
+++ b/yamanifest/hashing.py
@@ -33,7 +33,7 @@ one_hundred_megabytes = 104857600
 # calculation
 supported_hashes = ['nchash', 'md5', 'sha1', 'sha224', 'sha256', 'sha384', 'sha512']
 
-def hash(path, hashfn, size=one_hundred_megabytes, hash_file_info=True):
+def hash(path, hashfn, size=one_hundred_megabytes, hash_path_info=True):
     """ A simple wrapper that inspects the hashing function and intercepts
     calls to nchash and binhash so they are processed in a special way.
 
@@ -53,10 +53,12 @@ def hash(path, hashfn, size=one_hundred_megabytes, hash_file_info=True):
         elif hashfn == 'binhash':
             m = hashlib.new('md5')
             with io.open(path, mode="rb") as fd:
-                # Size limited hashing, so prepend the filename, size and modification time 
-                if hash_file_info:
-                    hashstring = os.path.basename(path) + str(os.path.getsize(path)) + str(os.path.getmtime(path))
-                    m.update(hashstring.encode())
+                # Size limited hashing, so prepend the size and optionally the filename
+                # and modification time
+                hashstring = str(os.path.getsize(path))
+                if hash_path_info:
+                    hashstring += os.path.basename(path) + str(os.path.getmtime(path))
+                m.update(hashstring.encode())
                 tot = 0
                 for chunk in iter(lambda: fd.read(length), b''):
                     tot += len(chunk)

--- a/yamanifest/hashing.py
+++ b/yamanifest/hashing.py
@@ -33,7 +33,7 @@ one_hundred_megabytes = 104857600
 # calculation
 supported_hashes = ['nchash', 'md5', 'sha1', 'sha224', 'sha256', 'sha384', 'sha512']
 
-def hash(path, hashfn, size=one_hundred_megabytes, hash_path_info=True):
+def hash(path, hashfn, size=one_hundred_megabytes, include_filename=True, include_mtime=True):
     """ A simple wrapper that inspects the hashing function and intercepts
     calls to nchash and binhash so they are processed in a special way.
 
@@ -56,8 +56,10 @@ def hash(path, hashfn, size=one_hundred_megabytes, hash_path_info=True):
                 # Size limited hashing, so prepend the size and optionally the filename
                 # and modification time
                 hashstring = str(os.path.getsize(path))
-                if hash_path_info:
-                    hashstring += os.path.basename(path) + str(os.path.getmtime(path))
+                if include_filename:
+                    hashstring += os.path.basename(path)
+                if include_mtime:
+                    hashstring += str(os.path.getmtime(path))
                 m.update(hashstring.encode())
                 tot = 0
                 for chunk in iter(lambda: fd.read(length), b''):

--- a/yamanifest/hashing.py
+++ b/yamanifest/hashing.py
@@ -31,7 +31,44 @@ one_hundred_megabytes = 104857600
 
 # List of supported hashes and the ordering used to determine relative expense of
 # calculation
-supported_hashes = ['nchash', 'md5', 'sha1', 'sha224', 'sha256', 'sha384', 'sha512']
+supported_hashes = ['nchash', 'binhash', 'md5', 'sha1', 'sha224', 'sha256', 'sha384', 'sha512']
+
+def _nchash(path):
+    hashval = ''
+    m = NCDataHash(path)
+    try:
+        hashval = m.gethash()
+    except NotNetcdfFileError as e:
+        sys.stderr.write(str(e))
+        hashval = None
+    return hashval
+
+def _binhash(path, size, include_mtime):
+    m = hashlib.new('md5')
+    with io.open(path, mode="rb") as fd:
+        # Size limited hashing, so prepend the filename, size and optionally modification time 
+        hashstring = str(os.path.getsize(path)) + os.path.basename(path)
+        if include_mtime:
+            hashstring +=str(os.path.getmtime(path))
+        m.update(hashstring.encode())
+        tot = 0
+        for chunk in iter(lambda: fd.read(length), b''):
+            tot += len(chunk)
+            if tot >= size:
+                rem = (size-tot)
+                if rem <= 0:
+                    break
+                chunk = chunk[:rem]
+            m.update(chunk)
+    return m.hexdigest()
+
+def _hashlib(path, hashfn):
+    # from https://stackoverflow.com/a/40961519
+    m = hashlib.new(hashfn)
+    with io.open(path, mode="rb") as fd:
+        for chunk in iter(lambda: fd.read(length), b''):
+            m.update(chunk)
+    return m.hexdigest()
 
 def hash(path, hashfn, size=one_hundred_megabytes):
     """ A simple wrapper that inspects the hashing function and intercepts
@@ -39,40 +76,17 @@ def hash(path, hashfn, size=one_hundred_megabytes):
 
     TODO: make plugins that allow this transparently
     """
-
+    if hashfn not in supported_hashes:
+        sys.stderr.write('\nUnsupported hash function {}, skipping {}\n'.format(hashfn, path))
     try:
         if hashfn == 'nchash':
-            hashval = ''
-            m = NCDataHash(path)
-            try:
-                hashval = m.gethash()
-            except NotNetcdfFileError as e:
-                sys.stderr.write(str(e))
-                hashval = None
-            return hashval
+            return _nchash(path)
         elif hashfn == 'binhash':
-            m = hashlib.new('md5')
-            with io.open(path, mode="rb") as fd:
-                # Size limited hashing, so prepend the filename, size and modification time 
-                hashstring = os.path.basename(path) + str(os.path.getsize(path)) + str(os.path.getmtime(path))
-                m.update(hashstring.encode())
-                tot = 0
-                for chunk in iter(lambda: fd.read(length), b''):
-                    tot += len(chunk)
-                    if tot >= size:
-                        rem = (size-tot)
-                        if rem <= 0:
-                            break
-                        chunk = chunk[:rem]
-                    m.update(chunk)
-            return m.hexdigest()
+            return _binhash(path, one_hundred_megabytes, True)
+        elif hashfn == 'binhash-nomtime':
+            return _binhash(path, one_hundred_megabytes, False)
         else:
-            # from https://stackoverflow.com/a/40961519
-            m = hashlib.new(hashfn)
-            with io.open(path, mode="rb") as fd:
-                for chunk in iter(lambda: fd.read(length), b''):
-                    m.update(chunk)
-            return m.hexdigest()
+            return _hashlib(path, hashfn)
     except IOError as e:
         sys.stderr.write('{}\nCannot hash, skipping {}\n'.format(str(e),path))
         return None

--- a/yamanifest/manifest.py
+++ b/yamanifest/manifest.py
@@ -123,7 +123,7 @@ class Manifest(object):
         """
         del(self.data[filepath])
 
-    def add(self, filepaths=None, hashfn=None, force=False, shortcircuit=False, fullpaths=None):
+    def add(self, filepaths=None, hashfn=None, force=False, shortcircuit=False, fullpaths=None, **kwargs):
         """
         Add hash value for filepath given a hashing function (hashfn).
         If no filepaths defined, default to all current filepaths, and in
@@ -182,7 +182,7 @@ class Manifest(object):
                 tmpfilepaths.append(filepath)
                 tmpfns.append(fn)
         
-        results = self.calc_hashes(tmpfilepaths, tmpfns)
+        results = self.calc_hashes(tmpfilepaths, tmpfns, **kwargs)
                 
         for filepath in results:
 
@@ -257,7 +257,7 @@ class Manifest(object):
 
         return hashval
         
-    def calc_hashes(self, filepaths, hashfns):
+    def calc_hashes(self, filepaths, hashfns, **kwargs):
         """
         Calculate hash values for a number of filepaths and hash function combinations
         """
@@ -269,7 +269,11 @@ class Manifest(object):
 
         # print("Queuing jobs")
         for filepath, fn in zip(filepaths,hashfns):
-            results[filepath][fn] = pool.apply_async(hash, args=(self.data[filepath]["fullpath"], fn))
+            results[filepath][fn] = pool.apply_async(
+                hash, 
+                args=(self.data[filepath]["fullpath"], fn),
+                kwds=kwargs
+            )
 
         pool.close()
         pool.join()
@@ -282,7 +286,7 @@ class Manifest(object):
 
         return results
 
-    def check_file(self, filepaths, hashfn=None, hashvals=None, shortcircuit=False, condition=all):
+    def check_file(self, filepaths, hashfn=None, hashvals=None, shortcircuit=False, condition=all, **kwargs):
         """
         Check hash value for a filepath given a hashing function (hashfn)
         matches stored hash value. Return values of non-matching hashes
@@ -334,7 +338,7 @@ class Manifest(object):
                     tmpfilepaths.append(filepath)
                     tmpfns.append(fn)
 
-        results = self.calc_hashes(tmpfilepaths, tmpfns)
+        results = self.calc_hashes(tmpfilepaths, tmpfns, **kwargs)
 
         for filepath in filepaths:
 

--- a/yamanifest/manifest.py
+++ b/yamanifest/manifest.py
@@ -123,7 +123,7 @@ class Manifest(object):
         """
         del(self.data[filepath])
 
-    def add(self, filepaths=None, hashfn=None, force=False, shortcircuit=False, fullpaths=None, **kwargs):
+    def add(self, filepaths=None, hashfn=None, force=False, shortcircuit=False, fullpaths=None):
         """
         Add hash value for filepath given a hashing function (hashfn).
         If no filepaths defined, default to all current filepaths, and in
@@ -182,7 +182,7 @@ class Manifest(object):
                 tmpfilepaths.append(filepath)
                 tmpfns.append(fn)
         
-        results = self.calc_hashes(tmpfilepaths, tmpfns, **kwargs)
+        results = self.calc_hashes(tmpfilepaths, tmpfns)
                 
         for filepath in results:
 
@@ -257,7 +257,7 @@ class Manifest(object):
 
         return hashval
         
-    def calc_hashes(self, filepaths, hashfns, **kwargs):
+    def calc_hashes(self, filepaths, hashfns):
         """
         Calculate hash values for a number of filepaths and hash function combinations
         """
@@ -269,11 +269,7 @@ class Manifest(object):
 
         # print("Queuing jobs")
         for filepath, fn in zip(filepaths,hashfns):
-            results[filepath][fn] = pool.apply_async(
-                hash, 
-                args=(self.data[filepath]["fullpath"], fn),
-                kwds=kwargs
-            )
+            results[filepath][fn] = pool.apply_async(hash, args=(self.data[filepath]["fullpath"], fn))
 
         pool.close()
         pool.join()
@@ -286,7 +282,7 @@ class Manifest(object):
 
         return results
 
-    def check_file(self, filepaths, hashfn=None, hashvals=None, shortcircuit=False, condition=all, **kwargs):
+    def check_file(self, filepaths, hashfn=None, hashvals=None, shortcircuit=False, condition=all):
         """
         Check hash value for a filepath given a hashing function (hashfn)
         matches stored hash value. Return values of non-matching hashes
@@ -338,7 +334,7 @@ class Manifest(object):
                     tmpfilepaths.append(filepath)
                     tmpfns.append(fn)
 
-        results = self.calc_hashes(tmpfilepaths, tmpfns, **kwargs)
+        results = self.calc_hashes(tmpfilepaths, tmpfns)
 
         for filepath in filepaths:
 


### PR DESCRIPTION
I've added a few `**kwargs` to the signatures of some Manifest methods to allow passing kw options through to the `hash` function.

I haven't added a test for this as there wasn't an obvious/quick place from my brief scan through. Happy to add one though if we think it's worthwhile. Incidentally, 3 tests failed before I made any changes at all. I haven't looked into this yet.

Closes #12 